### PR TITLE
[task] mudar nomenclatura da prop (ux-text-image)

### DIFF
--- a/src/components/ux/ux-text-image/index.tsx
+++ b/src/components/ux/ux-text-image/index.tsx
@@ -9,7 +9,7 @@ export function UxTextImage({ settings }: UxTextImageProps) {
     'data-image': settings.image,
     'data-button-href': settings.buttonHref,
     'data-button-label': settings.buttonLabel,
-    side: settings.side
+    'data-position': settings.position
   }
 
   defineUxTextImage()

--- a/src/components/ux/ux-text-image/types.ts
+++ b/src/components/ux/ux-text-image/types.ts
@@ -4,7 +4,7 @@ export interface UxTextImageSettings {
   image?: string
   buttonLabel?: string
   buttonHref?: string
-  side?: 'right' | 'left'
+  position?: 'right' | 'left'
 }
 
 export interface UxTextImageProps {


### PR DESCRIPTION
## [task] mudar nomenclatura da prop (ux-text-image)

### Changes:

- prop `side` alterada para `position`, assim como o `data` da prop, que foi adicionado